### PR TITLE
Add update check feedback popup

### DIFF
--- a/bin/bin/js/settings.js
+++ b/bin/bin/js/settings.js
@@ -53,8 +53,30 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const updateBtn = document.getElementById('updateButton');
   if (updateBtn) {
+    let userRequested = false;
     updateBtn.addEventListener('click', () => {
+      userRequested = true;
       window.electronAPI?.checkForUpdates();
     });
+    if (window.electronAPI) {
+      window.electronAPI.onUpdateAvailable(() => {
+        if (userRequested) {
+          alert('Update available!');
+          userRequested = false;
+        }
+      });
+      window.electronAPI.onUpdateNotAvailable(() => {
+        if (userRequested) {
+          alert('No updates found. You\'re up to date.');
+          userRequested = false;
+        }
+      });
+      window.electronAPI.onUpdateError((msg) => {
+        if (userRequested) {
+          alert(`Update check failed: ${msg}`);
+          userRequested = false;
+        }
+      });
+    }
   }
 });

--- a/main.js
+++ b/main.js
@@ -97,10 +97,15 @@ function initAutoUpdater() {
     autoUpdater.autoDownload = false;
     autoUpdater.on('error', (err) => {
         console.error('Auto updater error:', err);
+        if (win) win.webContents.send('update-error', err.message);
     });
 
     autoUpdater.on('update-available', () => {
         if (win) win.webContents.send('update-available');
+    });
+
+    autoUpdater.on('update-not-available', () => {
+        if (win) win.webContents.send('update-not-available');
     });
 
     autoUpdater.on('download-progress', (progressObj) => {

--- a/preload.js
+++ b/preload.js
@@ -12,6 +12,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   checkForUpdates: () => ipcRenderer.send('check-for-updates'),
   startUpdate: () => ipcRenderer.send('start-update'),
   onUpdateAvailable: (cb) => ipcRenderer.on('update-available', cb),
+  onUpdateNotAvailable: (cb) => ipcRenderer.on('update-not-available', cb),
+  onUpdateError: (cb) => ipcRenderer.on('update-error', (_, msg) => cb(msg)),
   onDownloadProgress: (cb) => ipcRenderer.on('download-progress', (_, p) => cb(p)),
   onUpdateDownloaded: (cb) => ipcRenderer.on('update-downloaded', cb)
 });


### PR DESCRIPTION
## Summary
- send auto-updater events to the renderer for success/failure
- expose new APIs in the preload script
- show alert popups when the user manually checks for updates

## Testing
- `npm run build` *(fails: electron-builder not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d17965aac8321ae5ead79181733f9