### PR TITLE
Add brutalist dark theme and unify theme logic

### DIFF
--- a/bin/bin/css/themes/brrutalist-dark.css
+++ b/bin/bin/css/themes/brrutalist-dark.css
@@ -1,0 +1,39 @@
+body.brutalist-d {
+  --bg-color: #1e1f22;
+  --shadow: #000000;
+  --bg-color-1: #2b2b2b;
+  --panel-bg: #1e1f22;
+  --border-color: #ffffff;
+  --text-color: #ffffff;
+  --highlight: #fff;
+  --blue: #2b2b2b;
+  --accent-green: #ffffff;
+  --accent-red: #ffffff;
+  --accent-yellow: #ffffff;
+  --accent-orange: #ffffff;
+  --accent-purple: #ffffff;
+  --accent-pink: #ffffff;
+  --accent-muted: #cccccc;
+  font-family: 'Press Start 2P', monospace;
+}
+
+body.brutalist-d *,
+body.brutalist-d #topHeader,
+body.brutalist-d footer {
+  font-family: 'Roboto Mono', monospace !important;
+}
+
+body.brutalist-d button,
+body.brutalist-d input,
+body.brutalist-d textarea,
+body.brutalist-d fieldset,
+body.brutalist-d .sidebar,
+body.brutalist-d .section,
+body.brutalist-d #dropZone {
+  box-shadow: none !important;
+  border-width: 2px !important;
+}
+
+body.brutalist-d .section {
+  border-color: var(--border-color) !important;
+}

--- a/bin/bin/js/theme.js
+++ b/bin/bin/js/theme.js
@@ -5,17 +5,45 @@ if (savedTheme === 'dark') {
   document.body.classList.add('dark');
 }
 
+const savedRetro = localStorage.getItem('retro64');
+if (savedRetro === 'true') {
+  document.body.classList.add('retro64');
+}
+
 const savedBrutal = localStorage.getItem('brutalist');
 if (savedBrutal === 'true') {
   document.body.classList.add('brutalist');
 }
+
 const savedBrutald = localStorage.getItem('brutalist-d');
 if (savedBrutald === 'true') {
   document.body.classList.add('brutalist-d');
 }
+
+function setupToggle(id, className, storageKey) {
+  const toggle = document.getElementById(id);
+  if (!toggle) return;
+  const enabled = storageKey === 'theme'
+    ? localStorage.getItem(storageKey) === 'dark'
+    : localStorage.getItem(storageKey) === 'true';
+  document.body.classList.toggle(className, enabled);
+  toggle.checked = enabled;
+  toggle.addEventListener('change', () => {
+    const active = toggle.checked;
+    document.body.classList.toggle(className, active);
+    if (storageKey === 'theme') {
+      localStorage.setItem(storageKey, active ? 'dark' : 'light');
+    } else {
+      localStorage.setItem(storageKey, active);
+    }
+  });
+}
+
 window.addEventListener('DOMContentLoaded', () => {
-  const isDark = document.body.classList.contains('dark');
-  document.getElementById('themeToggle').checked = isDark;
+  setupToggle('themeToggle', 'dark', 'theme');
+  setupToggle('retro64Toggle', 'retro64', 'retro64');
+  setupToggle('brutalistToggle', 'brutalist', 'brutalist');
+  setupToggle('brutalistDarkToggle', 'brutalist-d', 'brutalist-d');
 
   document.querySelectorAll('.hide-on-load').forEach(el => el.classList.add('hide-on-load'));
 

--- a/bin/bin/js/window-controls.js
+++ b/bin/bin/js/window-controls.js
@@ -17,41 +17,4 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  // Retro64 toggle
-  const retroToggle = document.getElementById('retro64Toggle');
-  if (retroToggle) {
-    const enabled = localStorage.getItem('retro64') === 'true';
-    document.body.classList.toggle('retro64', enabled);
-    retroToggle.checked = enabled;
-    retroToggle.addEventListener('change', () => {
-      const active = retroToggle.checked;
-      document.body.classList.toggle('retro64', active);
-      localStorage.setItem('retro64', active);
-    });
-  }
-
-  // Brutalist toggle
-  const brutalistToggle = document.getElementById('brutalistToggle');
-  if (brutalistToggle) {
-    const enabled = localStorage.getItem('brutalist') === 'true';
-    document.body.classList.toggle('brutalist', enabled);
-    brutalistToggle.checked = enabled;
-    brutalistToggle.addEventListener('change', () => {
-      const active = brutalistToggle.checked;
-      document.body.classList.toggle('brutalist', active);
-      localStorage.setItem('brutalist', active);
-    });
-  }
 });
-const brutalistToggle = document.getElementById('brutalistToggle');
-if (brutalistToggle) {
-  const enabled = localStorage.getItem('brutalist') === 'true';
-  document.body.classList.toggle('brutalist', enabled);
-  brutalistToggle.checked = enabled;
-
-  brutalistToggle.addEventListener('change', () => {
-    const active = brutalistToggle.checked;
-    document.body.classList.toggle('brutalist', active);
-    localStorage.setItem('brutalist', active);
-  });
-}

--- a/bin/index.html
+++ b/bin/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="bin/css/settings.css">
   <link rel="stylesheet" href="bin/css/titleBar.css">
   <link rel="stylesheet" href="bin/css/themes/brrutalist.css">
+  <link rel="stylesheet" href="bin/css/themes/brrutalist-dark.css">
   <link rel="stylesheet" href="bin/css/themes/r63.css">
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
@@ -69,13 +70,14 @@
         <div class="setting-item">
           <label for="brutalistToggle">Brutalist</label>
           <label class="toggle-switch">
-            <input type="checkbox" id="brutalistToggle" onchange="toggleBrutalist()" />
+            <input type="checkbox" id="brutalistToggle" />
             <span class="slider"></span>
+          </label>
         </div>
         <div class="setting-item">
-          <label for="brutalistToggle">Brutalist Dark</label>
+          <label for="brutalistDarkToggle">Brutalist Dark</label>
           <label class="toggle-switch">
-            <input type="checkbox" id="brutalistToggle" onchange="toggleBrutalist()" />
+            <input type="checkbox" id="brutalistDarkToggle" />
             <span class="slider"></span>
           </label>
         </div>


### PR DESCRIPTION
## Summary
- integrate Brutalist dark CSS theme and load it in HTML
- add toggles for Brutalist and Brutalist Dark with consistent logic
- move theme toggling logic into `theme.js`
- remove duplicated theme code from window controls

## Testing
- `npx eslint bin/bin/js/*.js` *(fails: ESLint couldn't find config)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685df15a59ac8321b9ee6eb032a43437