### PR TITLE
Add configurable debug log toggle

### DIFF
--- a/bin/bin/js/debug.js
+++ b/bin/bin/js/debug.js
@@ -1,0 +1,23 @@
+let debugEnabled = localStorage.getItem('debugEnabled') === 'true';
+
+window.debugLog = function (...args) {
+  if (debugEnabled) {
+    console.log(...args);
+  }
+};
+
+window.setDebugEnabled = function (enabled) {
+  debugEnabled = enabled;
+  localStorage.setItem('debugEnabled', String(enabled));
+  if (window.electronAPI?.toggleDebug) {
+    window.electronAPI.toggleDebug(enabled);
+  }
+};
+
+window.isDebugEnabled = function () {
+  return debugEnabled;
+};
+
+if (window.electronAPI?.toggleDebug) {
+  window.electronAPI.toggleDebug(debugEnabled);
+}

--- a/bin/bin/js/settings.js
+++ b/bin/bin/js/settings.js
@@ -62,7 +62,7 @@ window.addEventListener('DOMContentLoaded', () => {
   if (updateBtn) {
     let userRequested = false;
     updateBtn.addEventListener('click', () => {
-      console.log('[debug] update button clicked');
+      debugLog('[debug] update button clicked');
       userRequested = true;
       window.electronAPI?.checkForUpdates();
     });

--- a/bin/bin/js/update.js
+++ b/bin/bin/js/update.js
@@ -18,15 +18,27 @@ window.addEventListener('DOMContentLoaded', () => {
   const checkUpdateBtn = document.getElementById('updateButton');
   if (checkUpdateBtn) {
     const consoleBtn = document.createElement('button');
-    // consoleBtn.id = 'updateButton';
     consoleBtn.id = 'consoleButton';
     consoleBtn.textContent = 'Console';
     consoleBtn.className = checkUpdateBtn.className;
     consoleBtn.addEventListener('click', () => {
-      console.log('[debug] devtools button clicked');
+      debugLog('[debug] devtools button clicked');
       window.electronAPI.openDevTools();
     });
     checkUpdateBtn.insertAdjacentElement('afterend', consoleBtn);
+
+    const debugBtn = document.createElement('button');
+    debugBtn.id = 'debugButton';
+    debugBtn.className = checkUpdateBtn.className;
+    const updateText = () => {
+      debugBtn.textContent = isDebugEnabled() ? 'Debug On' : 'Debug Off';
+    };
+    updateText();
+    debugBtn.addEventListener('click', () => {
+      setDebugEnabled(!isDebugEnabled());
+      updateText();
+    });
+    consoleBtn.insertAdjacentElement('afterend', debugBtn);
   }
 
 
@@ -82,12 +94,12 @@ window.addEventListener('DOMContentLoaded', () => {
   });
 
   window.electronAPI.onDownloadProgress((percent) => {
-    console.log('[update] download progress', percent);
+    debugLog('[update] download progress', percent);
     updateBtn.textContent = `${Math.floor(percent)}%`;
   });
 
   window.electronAPI.onUpdateDownloaded(() => {
-    console.log('[update] update downloaded');
+    debugLog('[update] update downloaded');
     updateBtn.textContent = 'Restarting';
   });
   const el = document.getElementById('app-version');

--- a/bin/index.html
+++ b/bin/index.html
@@ -133,6 +133,7 @@
 
   <!-- Scripts -->
   <script src="https://cdn.jsdelivr.net/npm/js-yaml@4"></script>
+  <script src="bin/js/debug.js"></script>
   <script src="bin/js/theme.js"></script>
   <script src="bin/js/preload-data.js"></script>
   <script src="bin/js/preview.js"></script>

--- a/main.js
+++ b/main.js
@@ -5,6 +5,13 @@ const { version } = require('./package.json');
 
 let win;
 let previousBounds;
+let debugEnabled = false;
+
+function debugLog(...args) {
+    if (debugEnabled) {
+        console.log(...args);
+    }
+}
 
 function createWindow() {
     const binDir = app.isPackaged
@@ -86,14 +93,18 @@ ipcMain.on('window-maximize', (e) => {
 // Auto update IPC
 ipcMain.on('check-for-updates', () => {
     // console.log('[update] checking for updates');
-    console.log('[debug] received check-for-updates');
+    debugLog('[debug] received check-for-updates');
     // autoUpdater.checkForUpdatesAndNotify();
     autoUpdater.checkForUpdates();
 });
 
 ipcMain.on('start-update', () => {
-    console.log('[debug] received start-update');
+    debugLog('[debug] received start-update');
     autoUpdater.downloadUpdate();
+});
+
+ipcMain.on('toggle-debug', (_e, enabled) => {
+    debugEnabled = Boolean(enabled);
 });
 
 
@@ -110,22 +121,22 @@ function initAutoUpdater() {
     });
 
     autoUpdater.on('update-available', () => {
-        console.log('[update] update available (main)');
+        debugLog('[update] update available (main)');
         win?.webContents.send('update-available');
     });
 
     autoUpdater.on('update-not-available', () => {
-        console.log('[update] update not available (main)');
+        debugLog('[update] update not available (main)');
         win?.webContents.send('update-not-available');
     });
 
     autoUpdater.on('download-progress', (progress) => {
-        console.log(`[update] download progress (main) ${progress.percent}`);
+        debugLog(`[update] download progress (main) ${progress.percent}`);
         win?.webContents.send('download-progress', progress.percent);
     });
 
     autoUpdater.on('update-downloaded', () => {
-        console.log('[update] update downloaded (main)');
+        debugLog('[update] update downloaded (main)');
         win?.webContents.send('update-downloaded');
         autoUpdater.quitAndInstall();
     });

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "artifactName": "Harmony.Setup.${version}.${ext}",
     "win": {
       "publisherName": "Jan Gigantino"
+    },
     "extraResources": [
       {
         "from": "bin",

--- a/preload.js
+++ b/preload.js
@@ -19,7 +19,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onDownloadProgress: (cb) => ipcRenderer.on('download-progress', (_, p) => cb(p)),
   onUpdateDownloaded: (cb) => ipcRenderer.on('update-downloaded', cb),
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
-  openDevTools: () => ipcRenderer.send('open-devtools')
+  openDevTools: () => ipcRenderer.send('open-devtools'),
+  toggleDebug: (enabled) => ipcRenderer.send('toggle-debug', enabled)
   
 });
 


### PR DESCRIPTION
## Summary
- add new global debug.js module with `setDebugEnabled` and `debugLog`
- insert Debug button next to update and console controls
- pipe debug events from renderer to main
- wrap existing log statements behind debug toggle
- include debug script in index.html
- fix malformed `package.json`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685fcda3ea548321b8a3b79e10dd3336