### PR TITLE
Add advanced settings toggles

### DIFF
--- a/bin/bin/js/settings.js
+++ b/bin/bin/js/settings.js
@@ -5,6 +5,8 @@ window.addEventListener('DOMContentLoaded', () => {
   // const editor = document.querySelector('.editor-container');
   const settingsPanel = document.getElementById('settingsPanel');
   const highlightPicker = document.getElementById('highlightPicker');
+  const debugToggle = document.getElementById('debugToggle');
+  const consoleToggle = document.getElementById('consoleToggle');
 
   // Settings panel is now always visible, so disable toggle buttons
 
@@ -55,6 +57,25 @@ window.addEventListener('DOMContentLoaded', () => {
       const color = highlightPicker.value;
       document.documentElement.style.setProperty('--highlight', color);
       localStorage.setItem('highlightColor', color);
+    });
+  }
+
+  if (debugToggle) {
+    debugToggle.checked = window.isDebugEnabled ? window.isDebugEnabled() : false;
+    debugToggle.addEventListener('change', () => {
+      if (window.setDebugEnabled) {
+        window.setDebugEnabled(debugToggle.checked);
+      }
+    });
+  }
+
+  if (consoleToggle) {
+    consoleToggle.addEventListener('change', () => {
+      if (consoleToggle.checked) {
+        window.electronAPI?.openDevTools();
+      } else {
+        window.electronAPI?.closeDevTools?.();
+      }
     });
   }
 

--- a/bin/bin/js/update.js
+++ b/bin/bin/js/update.js
@@ -15,31 +15,7 @@ window.addEventListener('DOMContentLoaded', () => {
   });
   titleBar.appendChild(updateBtn);
 
-  const checkUpdateBtn = document.getElementById('updateButton');
-  if (checkUpdateBtn) {
-    const consoleBtn = document.createElement('button');
-    consoleBtn.id = 'consoleButton';
-    consoleBtn.textContent = 'Console';
-    consoleBtn.className = checkUpdateBtn.className;
-    consoleBtn.addEventListener('click', () => {
-      debugLog('[debug] devtools button clicked');
-      window.electronAPI.openDevTools();
-    });
-    checkUpdateBtn.insertAdjacentElement('afterend', consoleBtn);
 
-    const debugBtn = document.createElement('button');
-    debugBtn.id = 'debugButton';
-    debugBtn.className = checkUpdateBtn.className;
-    const updateText = () => {
-      debugBtn.textContent = isDebugEnabled() ? 'Debug On' : 'Debug Off';
-    };
-    updateText();
-    debugBtn.addEventListener('click', () => {
-      setDebugEnabled(!isDebugEnabled());
-      updateText();
-    });
-    consoleBtn.insertAdjacentElement('afterend', debugBtn);
-  }
 
 
 

--- a/bin/index.html
+++ b/bin/index.html
@@ -47,6 +47,7 @@
     <main id="mainDropArea">
       <div id="settingsPanel" class="settings-panel">
         <h3>Settings</h3>
+        <h4>Themes</h4>
         <div class="setting-item">
           <label for="themeToggle">Dark Mode</label>
           <label class="toggle-switch">
@@ -86,6 +87,21 @@
           <label for="D97Toggle">D97</label>
           <label class="toggle-switch">
             <input type="checkbox" id="D97Toggle" />
+            <span class="slider"></span>
+          </label>
+        </div>
+        <h4>Advance</h4>
+        <div class="setting-item">
+          <label for="debugToggle">Debug</label>
+          <label class="toggle-switch">
+            <input type="checkbox" id="debugToggle" />
+            <span class="slider"></span>
+          </label>
+        </div>
+        <div class="setting-item">
+          <label for="consoleToggle">Open Console</label>
+          <label class="toggle-switch">
+            <input type="checkbox" id="consoleToggle" />
             <span class="slider"></span>
           </label>
         </div>

--- a/main.js
+++ b/main.js
@@ -112,6 +112,10 @@ ipcMain.on('open-devtools', (e) => {
     const window = e.sender.getOwnerBrowserWindow();
     window.webContents.openDevTools();
 });
+ipcMain.on('close-devtools', (e) => {
+    const window = e.sender.getOwnerBrowserWindow();
+    window.webContents.closeDevTools();
+});
 ipcMain.handle('get-app-version', () => app.getVersion());
 function initAutoUpdater() {
     autoUpdater.on('error', (err) => {

--- a/preload.js
+++ b/preload.js
@@ -20,6 +20,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onUpdateDownloaded: (cb) => ipcRenderer.on('update-downloaded', cb),
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
   openDevTools: () => ipcRenderer.send('open-devtools'),
+  closeDevTools: () => ipcRenderer.send('close-devtools'),
   toggleDebug: (enabled) => ipcRenderer.send('toggle-debug', enabled)
   
 });


### PR DESCRIPTION
## Summary
- reorganize Settings panel with sections for Themes and Advance options
- add Debug and Console toggles in settings
- support closing DevTools
- drop debug/console buttons from update.js

## Testing
- `npm run build` *(fails: electron-builder not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd1c888888321bb0e3cf621fb3c10