### PR TITLE
Show welcome card only after updates

### DIFF
--- a/bin/bin/js/script.js
+++ b/bin/bin/js/script.js
@@ -229,24 +229,37 @@ document.addEventListener('keydown', e => {
 });
 
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const welcomeCard = document.getElementById('welcomeCard');
-    const closeBtn = document.getElementById('closeWelcomeBtn');
-    const dropZone = document.getElementById('dropZone');
-    const preloadContainer = document.getElementById('preloadContainer');
+document.addEventListener('DOMContentLoaded', () => {
+  const welcomeCard = document.getElementById('welcomeCard');
+  const closeBtn = document.getElementById('closeWelcomeBtn');
+  const dropZone = document.getElementById('dropZone');
+  const preloadContainer = document.getElementById('preloadContainer');
 
-    // Hide dropZone and preloadContainer initially
-    dropZone.style.display = 'none';
-    preloadContainer.style.display = 'none';
+  const showCard = localStorage.getItem('showWelcomeAfterUpdate') === 'true';
 
-    // Show them after the welcome card is dismissed
-    closeBtn.addEventListener('click', () => {
-      welcomeCard.style.opacity = '0';
-      welcomeCard.style.pointerEvents = 'none';
-      setTimeout(() => {
-        welcomeCard.remove();
-        dropZone.style.display = '';
-        preloadContainer.style.display = '';
-      }, 300);
-    });
+  if (!showCard) {
+    // User has already seen the welcome card - remove it immediately
+    welcomeCard.remove();
+    dropZone.style.display = '';
+    preloadContainer.style.display = '';
+    return;
+  }
+
+  // Hide dropZone and preloadContainer while the card is visible
+  dropZone.style.display = 'none';
+  preloadContainer.style.display = 'none';
+
+  // Show them after the welcome card is dismissed
+  closeBtn.addEventListener('click', () => {
+    welcomeCard.style.opacity = '0';
+    welcomeCard.style.pointerEvents = 'none';
+    setTimeout(() => {
+      welcomeCard.remove();
+      dropZone.style.display = '';
+      preloadContainer.style.display = '';
+      try {
+        localStorage.removeItem('showWelcomeAfterUpdate');
+      } catch {}
+    }, 300);
   });
+});

--- a/bin/bin/js/update.js
+++ b/bin/bin/js/update.js
@@ -85,6 +85,10 @@ window.addEventListener('DOMContentLoaded', () => {
 
   window.electronAPI.onUpdateDownloaded(() => {
     debugLog('[update] update downloaded');
+    // Show the welcome card on next launch after a successful update
+    try {
+      localStorage.setItem('showWelcomeAfterUpdate', 'true');
+    } catch {}
     updateBtn.textContent = 'Restarting';
   });
   const el = document.getElementById('app-version');


### PR DESCRIPTION
## Summary
- display welcome card once after an update
- store a flag in localStorage when an update is downloaded
- hide welcome card on load unless that flag is present

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `electron-builder` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619c594ef883218abfcfc32652a9fe