### PR TITLE
Implement titlebar double-click maximize toggle

### DIFF
--- a/bin/bin/js/window-controls.js
+++ b/bin/bin/js/window-controls.js
@@ -13,7 +13,7 @@ window.addEventListener('DOMContentLoaded', () => {
     dragZone.addEventListener('dblclick', (e) => {
       e.preventDefault();
       e.stopPropagation();
-      window.electronAPI?.maximize();
+      window.electronAPI?.doubleClickTitlebar();
     });
   }
 

--- a/main.js
+++ b/main.js
@@ -13,6 +13,31 @@ function debugLog(...args) {
     }
 }
 
+function toggleMaximize(window, sender) {
+    if (window._isFakeMaximized) {
+        if (window._previousBounds) {
+            window.setBounds(window._previousBounds);
+        }
+        window._isFakeMaximized = false;
+        sender.send('window-is-restored');
+    } else {
+        window._previousBounds = window.getBounds();
+
+        const primaryDisplay = screen.getPrimaryDisplay();
+        const { x, y, width, height } = primaryDisplay.workArea;
+
+        window.setBounds({
+            x: x + 10,
+            y: y + 10,
+            width: width - 20,
+            height: height - 20
+        });
+
+        window._isFakeMaximized = true;
+        sender.send('window-is-maximized');
+    }
+}
+
 function createWindow() {
     const binDir = app.isPackaged
         ? path.join(process.resourcesPath, 'bin')
@@ -65,29 +90,12 @@ ipcMain.on('window-minimize', (e) => {
 
 ipcMain.on('window-maximize', (e) => {
     const window = e.sender.getOwnerBrowserWindow();
+    toggleMaximize(window, e.sender);
+});
 
-    if (window._isFakeMaximized) {
-        if (window._previousBounds) {
-            window.setBounds(window._previousBounds);
-        }
-        window._isFakeMaximized = false;
-        e.sender.send('window-is-restored');
-    } else {
-        window._previousBounds = window.getBounds();
-
-        const primaryDisplay = screen.getPrimaryDisplay();
-        const { x, y, width, height } = primaryDisplay.workArea;
-
-        window.setBounds({
-            x: x + 10,
-            y: y + 10,
-            width: width - 20,
-            height: height - 20
-        });
-
-        window._isFakeMaximized = true;
-        e.sender.send('window-is-maximized');
-    }
+ipcMain.on('titlebar-dblclick', (e) => {
+    const window = e.sender.getOwnerBrowserWindow();
+    toggleMaximize(window, e.sender);
 });
 
 // Auto update IPC

--- a/preload.js
+++ b/preload.js
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   minimize: () => ipcRenderer.send('window-minimize'),
   toggleMaximize: () => ipcRenderer.send('window-maximize'),
   maximize: () => ipcRenderer.send('window-maximize'),
+  doubleClickTitlebar: () => ipcRenderer.send('titlebar-dblclick'),
   close: () => ipcRenderer.send('window-close'),
   onMaximize: (cb) => ipcRenderer.on('window-is-maximized', cb),
   onRestore: (cb) => ipcRenderer.on('window-is-restored', cb),


### PR DESCRIPTION
## Summary
- extract maximize logic into `toggleMaximize`
- add new `titlebar-dblclick` IPC event using the helper
- expose `doubleClickTitlebar` API in the preload script
- trigger new event from the renderer on title bar double-click

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861a8d66ae88321bcf119c8dd4043c5